### PR TITLE
Feat: 교수님 상세 정보 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import MainPage from '@/Pages/Main';
 import InterviewPage from '@/Pages/Media/Interview';
 import ProfessorPage from '@/Pages/Media/Professor';
 import GraduatePage from '@/Pages/Media/Graduate';
+import ProfessorDetailPage from '@/Pages/Media/Professor/SubPage';
 
 axios.defaults.withCredentials = true;
 
@@ -20,6 +21,10 @@ function App() {
           <Route path="cil" element={'CIL'} />
           <Route path="media">
             <Route path="professor" element={<ProfessorPage />} />
+            <Route
+              path="professor/professorDetail/:professorId"
+              element={<ProfessorDetailPage />}
+            />
             <Route path="graduate" element={<GraduatePage />} />
             <Route path="interview" element={<InterviewPage />} />
           </Route>

--- a/src/Pages/Media/Professor/Components/index.tsx
+++ b/src/Pages/Media/Professor/Components/index.tsx
@@ -31,8 +31,9 @@ const Professor = () => (
                 </ProfileBox>
               </GridSection>
               <ProfileText>
-                <h3>{item.professorName} 교수님</h3>
-                <span>{item.email}</span>
+                <h2>{item.professorName} 교수님</h2>
+                <p>{item.email}</p>
+                <p>{item.officeRoom}</p>
               </ProfileText>
             </GridSection>
           </Link>

--- a/src/Pages/Media/Professor/Components/index.tsx
+++ b/src/Pages/Media/Professor/Components/index.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import GridSection from '@/Components/Section';
 import { ProfessorInfo } from '@/Utils/Constants/professor';
+import { Link } from 'react-router-dom';
 import { ProfessorContainer, ProfessorComponent, ProfileBox, Profile, ProfileText } from './style';
 
 const Professor = () => (
@@ -7,7 +9,21 @@ const Professor = () => (
     {ProfessorInfo.map((item) => (
       <GridSection key={item.professorName} col6>
         <ProfessorComponent>
-          <a href={item.homePageUrl}>
+          <Link
+            to={`professorDetail/${item.professorId}`}
+            state={{
+              professorId: item.professorId,
+              profile: item.profile,
+              professorName: item.professorName,
+              email: item.email,
+              officeRoom: item.officeRoom,
+              education: item.education,
+              thesis: item.thesis,
+              book: item.book,
+              other: item.other,
+              homePageUrl: item.homePageUrl,
+            }}
+          >
             <GridSection col6>
               <GridSection col2>
                 <ProfileBox>
@@ -19,11 +35,10 @@ const Professor = () => (
                 <span>{item.email}</span>
               </ProfileText>
             </GridSection>
-          </a>
+          </Link>
         </ProfessorComponent>
       </GridSection>
     ))}
   </ProfessorContainer>
 );
-
 export default Professor;

--- a/src/Pages/Media/Professor/Components/style.ts
+++ b/src/Pages/Media/Professor/Components/style.ts
@@ -27,10 +27,8 @@ export const ProfessorComponent = styled.article`
   text-align: left;
 
   width: 100%;
-  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.12);
-  border: 1px solid #232323;
+  box-shadow: 0px 4px 5px rgba(0, 0, 0, 0.12);
   background-color: #ededed;
-  margin-bottom: 0.75rem;
   border-radius: 10px;
 
   object-fit: cover;

--- a/src/Pages/Media/Professor/SubPage/index.tsx
+++ b/src/Pages/Media/Professor/SubPage/index.tsx
@@ -1,0 +1,28 @@
+import { useParams, useLocation } from 'react-router-dom';
+import Header from '@/Components/Header';
+import GridSection from '@/Components/Section';
+import { TitleComponent } from '@/Components/Title';
+import { ProfessorType } from '@/@Types/professor';
+import { PageWrapper, PageContainer } from './style';
+
+const ProfessorDetailPage = () => {
+  const { professorId } = useParams();
+  const location = useLocation();
+  const selectedProfessor = location.state as ProfessorType;
+
+  return (
+    <div>
+      <PageWrapper>
+        <Header />
+        <PageContainer>
+          <GridSection col12>
+            <TitleComponent titleContent={`${selectedProfessor.professorName} 교수님`} />
+          </GridSection>
+        </PageContainer>
+      </PageWrapper>
+      <p>{professorId}</p>
+    </div>
+  );
+};
+
+export default ProfessorDetailPage;

--- a/src/Pages/Media/Professor/SubPage/index.tsx
+++ b/src/Pages/Media/Professor/SubPage/index.tsx
@@ -3,7 +3,17 @@ import Header from '@/Components/Header';
 import GridSection from '@/Components/Section';
 import { TitleComponent } from '@/Components/Title';
 import { ProfessorType } from '@/@Types/professor';
-import { PageWrapper, PageContainer } from './style';
+import Button from '@/Components/Button';
+import {
+  PageWrapper,
+  PageContainer,
+  ProfessorDetailComponent,
+  ProfessorSimpleComponent,
+  ProfessorProfileContainer,
+  ProfessorProfile,
+  ProfessorSimpleInfoContainer,
+  ProfessorDetailInfoContainer,
+} from './style';
 
 const ProfessorDetailPage = () => {
   const { professorId } = useParams();
@@ -15,12 +25,63 @@ const ProfessorDetailPage = () => {
       <PageWrapper>
         <Header />
         <PageContainer>
-          <GridSection col12>
+          <GridSection col12 wrap>
             <TitleComponent titleContent={`${selectedProfessor.professorName} 교수님`} />
+            <ProfessorDetailComponent>
+              <ProfessorSimpleComponent>
+                <GridSection col2>
+                  <ProfessorProfileContainer>
+                    <ProfessorProfile src={selectedProfessor.profile} />
+                  </ProfessorProfileContainer>
+                </GridSection>
+                <ProfessorSimpleInfoContainer>
+                  <p>{selectedProfessor.email}</p>
+                  <p>{selectedProfessor.officeRoom}</p>
+                  <p>{selectedProfessor.education}</p>
+                </ProfessorSimpleInfoContainer>
+              </ProfessorSimpleComponent>
+              <ProfessorDetailInfoContainer>
+                <h2>대표 논문</h2>
+                {!!selectedProfessor.thesis &&
+                  selectedProfessor.thesis.map((item) => (
+                    <p key={item.thesisTitle}>
+                      {!!item.thesisTitle && (
+                        <>
+                          {item.thesisTitle}, {item.thesisAuthor}, {item.thesisBook},
+                          {item.thesisPublicationYear}
+                        </>
+                      )}
+                    </p>
+                  ))}
+                <h2>저서</h2>
+                {!!selectedProfessor.book &&
+                  selectedProfessor.book.map((item) => (
+                    <p key={item.bookTitle}>
+                      {!!item.bookTitle && (
+                        <>
+                          {item.bookTitle}, {item.bookAuthor}, {item.bookWritingPage},
+                          {item.bookPublicationYear}
+                        </>
+                      )}
+                    </p>
+                  ))}
+                <h2>기타</h2>
+                {!!selectedProfessor.other &&
+                  selectedProfessor.other.map((item) => (
+                    <p key={item.otherTitle}>
+                      {!!item.otherTitle && (
+                        <>
+                          {item.otherType}, {item.otherTitle}, {item.otherApplicant},
+                          {item.otherNumber}, {item.otherApplicationYear}
+                        </>
+                      )}
+                    </p>
+                  ))}
+              </ProfessorDetailInfoContainer>
+            </ProfessorDetailComponent>
           </GridSection>
         </PageContainer>
       </PageWrapper>
-      <p>{professorId}</p>
     </div>
   );
 };

--- a/src/Pages/Media/Professor/SubPage/style.ts
+++ b/src/Pages/Media/Professor/SubPage/style.ts
@@ -9,3 +9,54 @@ export const PageContainer = styled.section`
   display: block;
   ${theme.common.flexCenterColumn};
 `;
+
+export const ProfessorDetailComponent = styled.div`
+  display: block;
+`;
+
+export const ProfessorSimpleComponent = styled.div`
+  display: flex;
+  width: 100%;
+  margin-top: 1.5rem;
+`;
+
+export const ProfessorProfileContainer = styled.div`
+  border: 1px solid #e6e6e6;
+  border-radius: 10px;
+  padding: 1.25rem 1.5rem 1.25rem 1.5rem;
+  overflow: hidden;
+`;
+
+export const ProfessorProfile = styled.img`
+  width: 9.375rem;
+  height: 9.375rem;
+  object-fit: cover;
+  border-radius: 50%;
+`;
+
+export const ProfessorSimpleInfoContainer = styled.div`
+  width: calc(67.25rem - 3rem);
+  margin-left: 1.5rem;
+  background-color: #d9d9d9;
+  border-radius: 10px;
+  padding: 1.5rem;
+  p {
+    color: #737373;
+  }
+`;
+
+export const ProfessorDetailInfoContainer = styled.div`
+  width: calc(100% - 3rem);
+  margin-top: 2rem;
+  padding: 0.5rem 1.5rem 1.5rem 1.5rem;
+
+  background-color: #d9d9d9;
+  border-radius: 10px;
+  p {
+    color: #737373;
+  }
+  h2 {
+    margin-bottom: 0.5rem;
+    margin-top: 1rem;
+  }
+`;

--- a/src/Pages/Media/Professor/SubPage/style.ts
+++ b/src/Pages/Media/Professor/SubPage/style.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+import theme from '@/Styles/theme';
+
+export const PageWrapper = styled.div`
+  display: block;
+`;
+
+export const PageContainer = styled.section`
+  display: block;
+  ${theme.common.flexCenterColumn};
+`;


### PR DESCRIPTION
### 🔨 관련 이슈

---
- #53 : 교수님 소개 페이지 구현

### 📝 설명

---
교수님 상세 정보 페이지의 레이아웃을 구현하였습니다.

### 📷 사진
---
![image](https://user-images.githubusercontent.com/80613583/206915256-21625665-4f27-412b-b7ac-2dba0a96cbb1.png)


