### PR TITLE
hotfix : add the main page post link

### DIFF
--- a/src/Pages/Main/Components/SubMenuList/index.tsx
+++ b/src/Pages/Main/Components/SubMenuList/index.tsx
@@ -1,5 +1,6 @@
 import { CommentTypes } from '@/Pages/Board/Post/types';
 import { Icon } from '@iconify/react';
+import { Link } from 'react-router-dom';
 import {
   SubMenuListContainer,
   TitleContainer,
@@ -18,7 +19,9 @@ export default function SubMenuList(props: SubMenuListProps) {
     <SubMenuListContainer>
       <TitleContainer>
         <h3>{title}</h3>
-        <Icon width="24" height="24" color="#333333" icon="ic:round-keyboard-arrow-right" />
+        <Link to="/board/free">
+          <Icon width="24" height="24" color="#333333" icon="ic:round-keyboard-arrow-right" />
+        </Link>
       </TitleContainer>
       <ListContainer>
         {hasData.length <= 0 && (

--- a/src/Pages/Main/Components/SubMenuList/types.ts
+++ b/src/Pages/Main/Components/SubMenuList/types.ts
@@ -1,5 +1,9 @@
 import { CommentTypes } from '@/Pages/Board/Post/types';
 
+export interface SubMenuTypes extends CommentTypes {
+  boardType: string;
+}
+
 export interface SubMenuListProps {
   title: string;
   hasData: CommentTypes[];


### PR DESCRIPTION


### 📝 설명

---

#67 : 메인 페이지 게시판 링크 구현
- 현재 API에 게시판 정보를 불러올 수가 없어 전체 게시판 링크만 구현해놓은 상태입니다.

